### PR TITLE
Hotfix issue 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,5 +32,4 @@
 	</repository>
     </repositories>
 
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,4 +24,13 @@
         <module>snowflake-nar</module>
     </modules>
 
+    <repositories>
+	<repository>
+	  <id>jcenter</id>
+	  <name>jcenter</name>
+	  <url>https://jcenter.bintray.com</url>
+	</repository>
+    </repositories>
+
+
 </project>


### PR DESCRIPTION
Resolves issue #7 related to maven builds using http to access jcenter resources, but on Jan 13 2020 jcenter began requiring https.   Added a repositories section specifically for jcenter in the top level pom.xml file.